### PR TITLE
On content tab, link "Extending Default Alert Schema" on navigation shows 404

### DIFF
--- a/assets/js/detail.js
+++ b/assets/js/detail.js
@@ -184,7 +184,7 @@
         if(docLink && docLink.match(/readme.md/gi)){
           docLink = getGitRawDocLink(docLink);
           var baseDocLink = docLink.replace(/readme.md/gi, "");
-          var baseDocGitLink = gitDocLink.replace(/readme.md/gi, "");
+          var baseDocGitLink = gitDocLink.replace(/readme.md/gi, "docs/");
 
           var httpLoadSPContentMD = new XMLHttpRequest();
           httpLoadSPContentMD.open("GET", baseDocLink + 'docs/contents.md', false);


### PR DESCRIPTION
Fixed - Corrected the base doc link path, added 'docs/' to the link so the corrected link looks like - https://github.com/fortinet-fortisoar/solution-pack-soar-framework/blob/release/2.0.2/docs/extending-default-alert-schema.md

Incorrect/broken link - https://github.com/fortinet-fortisoar/solution-pack-soar-framework/blob/release/2.0.2/extending-default-alert-schema.md

Verified the changes on sandbox - https://cybersponse-dev-corp.github.io/contenthub/detail.html?entity=sOARFramework&version=2.0.2&type=solutionpack